### PR TITLE
fix: avoid mutating array in filter helper

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -74,7 +74,8 @@ export function filterAndSort<T>(
   sortBy: keyof T,
   sortOrder: 'asc' | 'desc' = 'asc'
 ): T[] {
-  let filtered = items;
+  // Create a shallow copy to avoid mutating the original array when sorting
+  let filtered = [...items];
 
   if (searchTerm) {
     // Türkçe karakterleri normalize et


### PR DESCRIPTION
## Summary
- prevent unintended mutations in `filterAndSort` by sorting a copy of the array

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Could not find rule "prefer-const" in plugin "@typescript-eslint")*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_688dd49b519c8333aa337978d2587826