### PR TITLE
fix: resolve lint configuration and cleanup

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,7 +32,6 @@ export default tseslint.config(
         }
       ],
       '@typescript-eslint/no-explicit-any': 'warn',
-      '@typescript-eslint/prefer-const': 'error',
       '@typescript-eslint/no-non-null-assertion': 'warn',
       'no-console': ['warn', { allow: ['warn', 'error'] }],
       'prefer-const': 'error',

--- a/src/components/Stock/StockManagement.tsx
+++ b/src/components/Stock/StockManagement.tsx
@@ -74,7 +74,6 @@ export function StockManagement() {
   });
 
   const categories = ['Pamuk', 'Polyester', 'Viskon', 'Karışım', 'Diğer'];
-  const locations = ['Depo A - Raf 1', 'Depo A - Raf 2', 'Depo B - Raf 1', 'Depo B - Raf 2', 'Depo B - Raf 3'];
 
   // Statistics calculations
   const totalItems = stockItems.length;
@@ -109,9 +108,9 @@ export function StockManagement() {
     }
 
     // Apply sorting
-    return filtered.sort((a, b) => {
-      let aVal: any = a[sortBy];
-      let bVal: any = b[sortBy];
+      return filtered.sort((a, b) => {
+        const aVal: any = a[sortBy];
+        const bVal: any = b[sortBy];
 
       if (typeof aVal === 'string' && typeof bVal === 'string') {
         const comparison = aVal.localeCompare(bVal, 'tr-TR', { sensitivity: 'base' });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -43,7 +43,7 @@ export const VALIDATION_CONFIG = {
   maxNameLength: 100,
   maxDescriptionLength: 500,
   maxNotesLength: 1000,
-  phoneRegex: /^[\+]?[0-9\s\-\(\)]{10,}$/,
+  phoneRegex: /^\+?[0-9\s\-()]{10,}$/,
   emailRegex: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
 } as const;
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -52,7 +52,7 @@ export function validateEmail(email: string): boolean {
 }
 
 export function validatePhone(phone: string): boolean {
-  const phoneRegex = /^[\+]?[0-9\s\-\(\)]{10,}$/;
+  const phoneRegex = /^\+?[0-9\s\-()]{10,}$/;
   return phoneRegex.test(phone);
 }
 


### PR DESCRIPTION
## Summary
- remove non-existent `@typescript-eslint/prefer-const` rule
- simplify phone validation regexes
- drop unused StockManagement locations and convert sort values to const

## Testing
- `npm run lint` *(fails: 52 problems, 28 errors, 24 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688e1a20b8a08333b8c2002e9ca2b85e